### PR TITLE
Work with nflverse_data class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.3.0.9016
+Version: 4.3.0.9017
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 * Fix a bug that resulted in incorrect `xyac_mean_yardage` on 4th downs (#327)
 * Fix a bug that resulted in missing `xyac` information for plays involving J.O'Shaughnessy (#329)
 * Fix a bug that resulted in missing `epa` on the last play of some games involving NE and BUF (#331)
-* Added new function `calculate_standings()` that computes regular season division standings and playoff seeds from play-by-play data.
+* Added new function `calculate_standings()` that computes regular season division standings and playoff seeds from nflverse data.
 * `fast_scraper()` and `build_nflfastR_pbp()` now return data frames of class `nflverse_data` to be consistent with `nflreadr`.
 
 # nflfastR 4.3.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Fix a bug that resulted in missing `xyac` information for plays involving J.O'Shaughnessy (#329)
 * Fix a bug that resulted in missing `epa` on the last play of some games involving NE and BUF (#331)
 * Added new function `calculate_standings()` that computes regular season division standings and playoff seeds from play-by-play data.
+* `fast_scraper()` and `build_nflfastR_pbp()` now return data frames of class `nflverse_data` to be consistent with `nflreadr`.
 
 # nflfastR 4.3.0
 

--- a/R/build_nflfastR_pbp.R
+++ b/R/build_nflfastR_pbp.R
@@ -28,7 +28,7 @@
 #' @inheritParams fast_scraper
 #' @param decode If `TRUE`, the function [decode_player_ids()] will be executed.
 #' @param rules If `FALSE`, printing of the header and footer in the console output will be suppressed.
-#' @return An nflfastR play-by-play data frame like it can be loaded from <https://github.com/nflverse/nflfastR-data>.
+#' @return An nflfastR play-by-play data frame like it can be loaded from <https://github.com/nflverse/nflverse-data>.
 #' @details To load valid game_ids please use the package function [fast_scraper_schedules()].
 #' @seealso For information on parallel processing and progress updates please
 #' see [nflfastR].
@@ -86,5 +86,5 @@ build_nflfastR_pbp <- function(game_ids,
 
   if (isTRUE(rules)) rule_footer("DONE")
 
-  return(ret)
+  make_nflverse_data(ret)
 }

--- a/R/calculate_standings.R
+++ b/R/calculate_standings.R
@@ -1,11 +1,17 @@
 #' Compute Division Standings and Conference Seeds from Play by Play
 #'
-#' @param pbp nflfastR play-by-play data either loaded via `load_pbp()` or
-#'   computed via `build_nflfastR_pbp()`.
+#' @description This function calculates division standings as well as playoff
+#'   seeds per conference based on either nflverse play-by-play data or nflverse
+#'   schedule data.
+#'
+#' @param nflverse_object Data object of class `nflverse_data`. Either schedules
+#'   as returned by [`fast_scraper_schedules()`] or [`nflreadr::load_schedules()`].
+#'   Or play-by-play data as returned by [`load_pbp()`], [`build_nflfastR_pbp()`], or
+#'  [`fast_scraper()`].
 #' @param playoff_seeds Number of playoff teams per conference. If `NULL` (the
-#'   default), the function will try to split `pbp` in seasons prior 2020 (6
-#'   seeds) and 2020ff (7 seeds). If set to a numeric, it will be used for all
-#'   seasons in `pbp`!
+#'   default), the function will try to split `nflverse_object` into seasons prior
+#'   2020 (6 seeds) and 2020ff (7 seeds). If set to a numeric, it will be used
+#'   for all seasons in `nflverse_object`!
 #' @inheritParams nflseedR::compute_conference_seeds
 #'
 #' @return A tibble with NFL regular season standings
@@ -14,19 +20,48 @@
 #' @examples
 #' \donttest{
 #' try({# to avoid CRAN test problems
-#'   pbp <- nflreadr::load_pbp(c(2018, 2021))
+#'   # load nflverse data both schedules and pbp
+#'   scheds <- fast_scraper_schedules(2014)
+#'   pbp <- load_pbp(c(2018, 2021))
+#'
+#'   # calculate standings based on pbp
 #'   calculate_standings(pbp)
+#'
+#'   # calculate standings based on schedules
+#'   calculate_standings(scheds)
 #' })
 #' }
-calculate_standings <- function(pbp,
+calculate_standings <- function(nflverse_object,
                                 tiebreaker_depth = 3,
                                 playoff_seeds = NULL){
+
+  if(!inherits(nflverse_object, "nflverse_data")){
+    cli::cli_abort("The function argument {.arg nflverse_object} has to be
+                   of class {.cls nflverse_data}")
+  }
 
   rlang::check_installed("nflseedR", "to compute standings.",
                          compare = ">=",
                          version = "1.0.2"
                          )
 
+  type <- attr(nflverse_object, "nflverse_type")
+
+  if (type == "play by play"){
+    .standings_from_pbp(nflverse_object,
+                        tiebreaker_depth = tiebreaker_depth,
+                        playoff_seeds = playoff_seeds)
+  } else if (type == "games and schedules"){
+    .standings_from_games(nflverse_object,
+                          tiebreaker_depth = tiebreaker_depth,
+                          playoff_seeds = playoff_seeds)
+  } else {
+    cli::cli_abort("Can only handle nflverse_type {.val play by play} or
+                   {.val games and schedules} and not {.val {type}}")
+  }
+}
+
+.standings_from_pbp <- function(pbp, tiebreaker_depth, playoff_seeds){
   g <- pbp %>%
     dplyr::filter(.data$season_type == "REG") %>%
     dplyr::group_by(.data$game_id) %>%
@@ -57,7 +92,31 @@ calculate_standings <- function(pbp,
   }
 }
 
+.standings_from_games <- function(games, tiebreaker_depth, playoff_seeds){
+  g <- games %>%
+    dplyr::filter(.data$game_type == "REG") %>%
+    dplyr::select(
+      "sim" = "season", "game_type", "week", "away_team", "home_team", "result"
+    )
+
+  if(is.null(playoff_seeds)){
+    g6 <- g %>%
+      dplyr::filter(sim %in% 1999:2019)
+    g7 <- g %>%
+      dplyr::filter(sim >= 2020)
+    dplyr::bind_rows(
+      .compute_standings(g6, tiebreaker_depth = tiebreaker_depth, playoff_seeds = 6),
+      .compute_standings(g7, tiebreaker_depth = tiebreaker_depth, playoff_seeds = 7)
+    )
+  } else {
+    .compute_standings(g,
+                       tiebreaker_depth = tiebreaker_depth,
+                       playoff_seeds = playoff_seeds)
+  }
+}
+
 .compute_standings <- function(games, tiebreaker_depth, playoff_seeds){
+  if(nrow(games) == 0) return(data.frame())
   suppressMessages({
     div <- nflseedR::compute_division_ranks(games,
                                             tiebreaker_depth = tiebreaker_depth)

--- a/R/top-level_scraper.R
+++ b/R/top-level_scraper.R
@@ -448,7 +448,7 @@ fast_scraper <- function(game_ids,
     str <- paste0(my_time(), " | Procedure completed.")
     cli::cli_alert_success("{.field {str}}")
   }
-  return(pbp)
+  make_nflverse_data(pbp)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -179,3 +179,11 @@ write_pbp <- function(seasons, dbConnection, tablename){
     p("loading...")
   }, p)
 }
+
+make_nflverse_data <- function(data, type = c("play by play")){
+  attr(data, "nflverse_timestamp") <- Sys.time()
+  attr(data, "nflverse_type") <- type
+  attr(data, "nflfastR_version") <- packageVersion("nflfastR")
+  class(data) <- c("nflverse_data", "tbl_df", "tbl", "data.table", "data.frame")
+  data
+}

--- a/man/build_nflfastR_pbp.Rd
+++ b/man/build_nflfastR_pbp.Rd
@@ -17,7 +17,7 @@ build_nflfastR_pbp(game_ids, ..., decode = TRUE, rules = TRUE)
 \item{rules}{If \code{FALSE}, printing of the header and footer in the console output will be suppressed.}
 }
 \value{
-An nflfastR play-by-play data frame like it can be loaded from \url{https://github.com/nflverse/nflfastR-data}.
+An nflfastR play-by-play data frame like it can be loaded from \url{https://github.com/nflverse/nflverse-data}.
 }
 \description{
 \code{build_nflfastR_pbp} is a convenient wrapper around 6 nflfastR functions:

--- a/man/calculate_standings.Rd
+++ b/man/calculate_standings.Rd
@@ -4,11 +4,17 @@
 \alias{calculate_standings}
 \title{Compute Division Standings and Conference Seeds from Play by Play}
 \usage{
-calculate_standings(pbp, tiebreaker_depth = 3, playoff_seeds = NULL)
+calculate_standings(
+  nflverse_object,
+  tiebreaker_depth = 3,
+  playoff_seeds = NULL
+)
 }
 \arguments{
-\item{pbp}{nflfastR play-by-play data either loaded via \code{load_pbp()} or
-computed via \code{build_nflfastR_pbp()}.}
+\item{nflverse_object}{Data object of class \code{nflverse_data}. Either schedules
+as returned by \code{\link[=fast_scraper_schedules]{fast_scraper_schedules()}} or \code{\link[nflreadr:load_schedules]{nflreadr::load_schedules()}}.
+Or play-by-play data as returned by \code{\link[=load_pbp]{load_pbp()}}, \code{\link[=build_nflfastR_pbp]{build_nflfastR_pbp()}}, or
+\code{\link[=fast_scraper]{fast_scraper()}}.}
 
 \item{tiebreaker_depth}{A single value equal to 1, 2, or 3. The default is 3. The
 value controls the depth of tiebreakers that shall be applied. The deepest
@@ -21,21 +27,30 @@ values are valid:
 }}
 
 \item{playoff_seeds}{Number of playoff teams per conference. If \code{NULL} (the
-default), the function will try to split \code{pbp} in seasons prior 2020 (6
-seeds) and 2020ff (7 seeds). If set to a numeric, it will be used for all
-seasons in \code{pbp}!}
+default), the function will try to split \code{nflverse_object} into seasons prior
+2020 (6 seeds) and 2020ff (7 seeds). If set to a numeric, it will be used
+for all seasons in \code{nflverse_object}!}
 }
 \value{
 A tibble with NFL regular season standings
 }
 \description{
-Compute Division Standings and Conference Seeds from Play by Play
+This function calculates division standings as well as playoff
+seeds per conference based on either nflverse play-by-play data or nflverse
+schedule data.
 }
 \examples{
 \donttest{
 try({# to avoid CRAN test problems
-  pbp <- nflreadr::load_pbp(c(2018, 2021))
+  # load nflverse data both schedules and pbp
+  scheds <- fast_scraper_schedules(2014)
+  pbp <- load_pbp(c(2018, 2021))
+
+  # calculate standings based on pbp
   calculate_standings(pbp)
+
+  # calculate standings based on schedules
+  calculate_standings(scheds)
 })
 }
 }


### PR DESCRIPTION
- pbp is now returned as nflverse_data class. schedules and rosters use nflreadr anyways so this was inconsistent and we can use the class for the next point
- standings can be calculated with both pbp and schedules