### PR TITLE
decoder for 2022 ids catches multiple runs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.4.0.9002
+Version: 4.4.0.9003
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/R/helper_decode_player_ids.R
+++ b/R/helper_decode_player_ids.R
@@ -85,7 +85,14 @@ decode_player_ids <- function(pbp, ..., fast = TRUE) {
           tidyselect::any_of(c("passer_id", "rusher_id", "receiver_id", "id", "fantasy_id")),
           tidyselect::ends_with("player_id")
         ),
-        function(id, id_vec = id_vector) id_vec[id]
+        function(id, id_vec = id_vector){
+          chars <- nchar(id)
+          dplyr::case_when(
+            is.na(chars) ~ NA_character_,
+            chars == 36 ~ id_vec[id],
+            TRUE ~ id
+          )
+        }
       )
   } else if (isTRUE(fast)) {
     if (!is_installed("gsisdecoder")) {


### PR DESCRIPTION
This is necessary because we may try to decode again and don't want to loose all IDs