### PR TITLE
fix def stats for missing fumble stats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.4.0.9009
+Version: 4.4.0.9010
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Fix Amon-Ra St. Brown breaking the name parser
 * import/export `nflverse_sitrep`
 * Add gsis_id patch to `clean_pbp()`. (v4.4.0.9009)
+* `calculate_player_stats_def()` failed in situations where play-by-play data is missing certain stats. (#382) (v4.4.0.9010)
 
 # nflfastR 4.4.0
 

--- a/R/aggregate_game_stats_def.R
+++ b/R/aggregate_game_stats_def.R
@@ -306,10 +306,10 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       values_fill = 0
     ) %>%
     # Renaming fails if the columns don't exist. So we row bind a dummy tibble
-    # including the relevat columns. The row will be filtered after renaming
+    # including the relevant columns. The row will be filtered after renaming
     dplyr::bind_rows(
       tibble::tibble(
-        player_id = NA_character_, fumbled = 0, fumble_recovery = 0
+        player_id = NA_character_, fumbled = numeric(), fumble_recovery = numeric()
       )
     ) %>%
     dplyr::rename(


### PR DESCRIPTION
fixes #382 

-- ensures that `fumbled_1_player_id` is always of type character,
-- allows column renaming even if data is missing by row binding a dummy tibble