### PR TITLE
fix standings from schedules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.5.0
+Version: 4.5.0.9000
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# nflfastR (development version)
+
+* `calculate_standings()` no more freezes when computing standings from schedules where some games are missing results, i.e. upcoming games. (v4.5.0.9000)
+
 # nflfastR 4.5.0
 
 ## New (experimental) functions

--- a/R/calculate_standings.R
+++ b/R/calculate_standings.R
@@ -94,7 +94,7 @@ calculate_standings <- function(nflverse_object,
 
 .standings_from_games <- function(games, tiebreaker_depth, playoff_seeds){
   g <- games %>%
-    dplyr::filter(.data$game_type == "REG") %>%
+    dplyr::filter(.data$game_type == "REG", !is.na(.data$result)) %>%
     dplyr::select(
       "sim" = "season", "game_type", "week", "away_team", "home_team", "result"
     )


### PR DESCRIPTION
closes #398 
Standings calculation did not filter NA results of upcoming games. This caused the function to freeze 