### PR TITLE
`calculate_player_stats_def()` no longer errors with small subsets of pbp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.5.1.9002
+Version: 4.5.1.9003
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - internal function `get_pbp_nfl()` now uses `ifelse()` instead of `dplyr::if_else()` to handle some null-checking, fixes bug found in 2022_21_CIN_KC match. (v4.5.1.9001)
 - The function `calculate_player_stats()` now summarises target share and air yards share correctly when called with argument `weekly = FALSE` (#413)
+- The function `calculate_player_stats_def()` no longer errors when small subsets of pbp data are missing stats. (#415)
 
 # nflfastR 4.5.1
 

--- a/R/aggregate_game_stats_def.R
+++ b/R/aggregate_game_stats_def.R
@@ -200,7 +200,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       names_from = .data$desc,
       values_from = c(.data$n, .data$sack_yards),
       values_fn = sum,
-      values_fill = 0
+      values_fill = 0L
     ) %>%
     add_column_if_missing("n_sack", "n_qb_hit", "sack_yards_sack") %>%
     dplyr::select(
@@ -248,7 +248,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       names_from = "desc",
       values_from = c("n","return_yards"),
       values_fn = sum,
-      values_fill = 0
+      values_fill = 0L
     ) %>%
     add_column_if_missing(
       "n_interception", "n_pass_defense", "return_yards_interception"
@@ -313,7 +313,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       names_from = .data$desc,
       values_from = .data$n,
       values_fn = sum,
-      values_fill = 0
+      values_fill = 0L
     ) %>%
     # Renaming fails if the columns don't exist. So we row bind a dummy tibble
     # including the relevant columns. The row will be filtered after renaming
@@ -367,7 +367,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       names_from = .data$desc,
       values_from = .data$n,
       values_fn = sum,
-      values_fill = 0
+      values_fill = 0L
     ) %>%
     dplyr::filter(!is.na(.data$player_id)) %>%
     add_column_if_missing("fumble_recovery") %>%
@@ -456,7 +456,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
       names_from = .data$desc,
       values_from = c(.data$n, .data$yards),
       values_fn = sum,
-      values_fill = 0
+      values_fill = 0L
     ) %>%
     add_column_if_missing("n_penalty", "yards_penalty") %>%
     dplyr::select(
@@ -603,7 +603,7 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
 # This function checks if the variables in ... exists as column
 # names in the argument .data. If not, it adds those columns and assigns
 # them the value in the argument value
-add_column_if_missing <- function(.data, ..., value = 0){
+add_column_if_missing <- function(.data, ..., value = 0L){
   dots <- rlang::list2(...)
   new_cols <- dots[!dots %in% names(.data)]
   .data[,unlist(new_cols)] <- value


### PR DESCRIPTION
if the pbp subset is small, there could be several columns missing which results in dplyr errors. 

This PR fixes that behavior by adding the relevant columns if they are missing

closes #410