### PR TITLE
calculate_series_conversion_rates handles small samples of pbp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.5.1.9003
+Version: 4.5.1.9004
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/R/calculate_series_conversion_rates.R
+++ b/R/calculate_series_conversion_rates.R
@@ -159,15 +159,15 @@ calculate_series_conversion_rates <- function(pbp,
 
 # Offense + Defense -------------------------------------------------------
 
-  combined <- dplyr::left_join(offense, defense, by = c("season", "team", "week"))
+  combined <- dplyr::full_join(offense, defense, by = c("season", "team", "week"))
 
   if (isFALSE(weekly)){
     combined <- combined %>%
       dplyr::select(-"week") %>%
       dplyr::group_by(.data$season, .data$team) %>%
       dplyr::summarise(
-        dplyr::across(.cols = dplyr::ends_with("_n"), .fns = sum),
-        dplyr::across(.cols = !dplyr::ends_with("_n"), .fns = mean),
+        dplyr::across(.cols = dplyr::ends_with("_n"), .fns = ~ sum(.x, na.rm = TRUE)),
+        dplyr::across(.cols = !dplyr::ends_with("_n"), .fns = ~ mean(.x, na.rm = TRUE)),
         .groups = "drop"
       ) %>%
       dplyr::relocate("def_n", .after = "off_to")


### PR DESCRIPTION
switch to full join in case there is no offensive series in pbp drop na for weekly = FALSE summary to avoid NA values in the summary

fixes #416 