### PR TITLE
increment fixed drive on lost fumbles with play type pass, run or punt

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest,    r: 'release'}
+          - {os: windows-latest,  r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
@@ -30,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -43,9 +43,12 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            rcmdcheck
+            any::rcmdcheck
             nflverse/fastrmodels
             nflverse/nflreadr
             nflverse/nflseedR
+          needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,17 +1,22 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
     branches: [main, master]
-    tags: ['*']
   pull_request:
-    branches: [master, main]
+    branches: [main, master]
+  release:
+    types: [published]
   workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
@@ -19,13 +24,14 @@ jobs:
       isPush: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -43,23 +49,17 @@ jobs:
             local::.
           needs: website
 
-      - name: Build and deploy pkgdown site
-        if: contains(env.isPush, 'true')
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
-
-      - name: Create website
-        if: contains(env.isPush, 'false')
-        run: |
-          pkgdown::build_site()
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      # - name: Create index file
-      #   if: contains(env.isPush, 'false')
-      #   run: |
-      #     echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;URL=/dev/index.html" />  <script language="javascript"> window.location.replace('/dev/index.html')</script></head></html>' > ./docs/index.html
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs
 
       - name: Deploy to Netlify
         if: contains(env.isPush, 'false')

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.5.1.9004
+Version: 4.5.1.9005
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - The function `calculate_player_stats()` now returns the opponent team when called with argument `weekly = TRUE` (#414)
 - The function `calculate_player_stats_def()` no longer errors when small subsets of pbp data are missing stats. (#415)
 - The function `calculate_series_conversion_rates()` no longer returns `NA` values if a small subset of pbp data is missing series on offense or defense. (#417)
+- `fixed_drive` now correctly increments on plays where posteam lost a fumble but remains posteam because defteam also lost a fumble during the same play. (#419)
 
 # nflfastR 4.5.1
 

--- a/R/report.R
+++ b/R/report.R
@@ -9,8 +9,18 @@
 #' @inherit nflreadr::nflverse_sitrep
 #' @examples
 #' \donttest{
+#' \dontshow{
+#' # set CRAN mirror to avoid failing checks in weird scenarios
+#' old_ops <- options(repos = c("CRAN" = "https://cran.rstudio.com/"))
+#' }
+#'
 #' report(recursive = FALSE)
 #' nflverse_sitrep(pkg = "nflreadr", recursive = TRUE)
+#'
+#' \dontshow{
+#' # restore old options
+#' options(old_ops)
+#' }
 #' }
 #' @export
 report <- function(...) nflreadr::nflverse_sitrep(...)

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![CRAN status](https://www.r-pkg.org/badges/version-last-release/nflfastR)](https://CRAN.R-project.org/package=nflfastR)
 [![CRAN downloads](http://cranlogs.r-pkg.org/badges/grand-total/nflfastR)](https://CRAN.R-project.org/package=nflfastR)
 [![Dev status](https://img.shields.io/github/r-package/v/nflverse/nflfastR/master?label=dev%20version&style=flat-square&logo=github)](https://www.nflfastr.com/)
-[![R-CMD-check](https://github.com/nflverse/nflfastR/workflows/R-CMD-check/badge.svg)](https://github.com/nflverse/nflfastR/actions)
+[![R-CMD-check](https://github.com/nflverse/nflfastR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nflverse/nflfastR/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![nflverse support](https://img.shields.io/discord/789805604076126219?color=7289da&label=nflverse%20support&logo=discord&logoColor=fff&style=flat-square)](https://discord.com/invite/5Er2FBnnQa)
 [![Twitter Follow](https://img.shields.io/twitter/follow/nflfastR.svg?style=social)](https://twitter.com/nflfastR)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ status](https://www.r-pkg.org/badges/version-last-release/nflfastR)](https://CRA
 downloads](http://cranlogs.r-pkg.org/badges/grand-total/nflfastR)](https://CRAN.R-project.org/package=nflfastR)
 [![Dev
 status](https://img.shields.io/github/r-package/v/nflverse/nflfastR/master?label=dev%20version&style=flat-square&logo=github)](https://www.nflfastr.com/)
-[![R-CMD-check](https://github.com/nflverse/nflfastR/workflows/R-CMD-check/badge.svg)](https://github.com/nflverse/nflfastR/actions)
+[![R-CMD-check](https://github.com/nflverse/nflfastR/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/nflverse/nflfastR/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![nflverse

--- a/man/report.Rd
+++ b/man/report.Rd
@@ -36,7 +36,17 @@ See \code{\link[nflreadr:sitrep]{nflreadr::nflverse_sitrep}} for details.
 }
 \examples{
 \donttest{
+\dontshow{
+# set CRAN mirror to avoid failing checks in weird scenarios
+old_ops <- options(repos = c("CRAN" = "https://cran.rstudio.com/"))
+}
+
 report(recursive = FALSE)
 nflverse_sitrep(pkg = "nflreadr", recursive = TRUE)
+
+\dontshow{
+# restore old options
+options(old_ops)
+}
 }
 }


### PR DESCRIPTION
fixes #418 

We already incremented fixed drive on lost fumbles (with later recovery in the same play) of punts and on interceptions. 

We didn't do it for run plays nor did we for pass plays with completed passes. 

The missing run plays were the cause of #418. But there were about 20 other plays from 1999:2022 affected by not doing it on completed passes. 

I changed it to increment on punt, pass and run (for now). It fixes all relevant plays and doesn't change anything else. So this should be good to go. 