### PR TITLE
`calculate_player_stats_def` now returns `season_type` if argument `weekly` is set to `TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.6.1.9000
+Version: 4.6.1.9001
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # nflfastR (development version)
 
 - Drop `{crayon}`, `{DT}`, `{httr}`, `{jsonlite}`, `{qs}` dependencies. (#453)
+- The function `calculate_player_stats_def` now returns `season_type` if argument `weekly` is set to `TRUE` for consistency with the other player stats functions. (#455) 
 
 # nflfastR 4.6.1
 

--- a/R/aggregate_game_stats_def.R
+++ b/R/aggregate_game_stats_def.R
@@ -81,6 +81,10 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
 
   })
 
+  stype <- data %>%
+    dplyr::select("season", "week", "season_type") %>%
+    dplyr::distinct()
+
   # Tackling stats -----------------------------------------------------------
 
   tackle_vars <- c(
@@ -512,11 +516,13 @@ calculate_player_stats_def <- function(pbp, weekly = FALSE) {
         ),
       by = "player_id"
     ) %>%
+    dplyr::left_join(stype, by = c("season", "week")) %>%
     dplyr::select(tidyselect::any_of(c(
 
       # game information
       "season",
       "week",
+      "season_type",
 
       # id information
       "player_id",


### PR DESCRIPTION
this is part of some adjustments for #454 