### PR TITLE
automatically recognize ID version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.6.1.9002
+Version: 4.6.1.9003
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Drop `{crayon}`, `{DT}`, `{httr}`, `{jsonlite}`, `{qs}` dependencies. (#453)
 - The function `calculate_player_stats_def` now returns `season_type` if argument `weekly` is set to `TRUE` for consistency with the other player stats functions. (#455)
 - The function `missing_raw_pbp()` now allows filtering by season. (#457)
+- More robust handling of player IDs in `decode_player_ids()`. (#458)
 
 # nflfastR 4.6.1
 


### PR DESCRIPTION
We are going to run into the problem that some older seasons could switch player IDs if we have to reload the raw pbp data for some reason, e.g. #456. 

This messes up the current approach where we assumed that 2023+ uses Elias IDs and older seasons remain with gsis.

This PR allows nflfastR to identify the player ID as gsis or elias and decode the ID regardless of version.