### PR TITLE
no kick off if previous play is weather delay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.6.1.9006
+Version: 4.6.1.9007
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Fixed rare cases where `drive_start_yard_line` missed the blank space between team name and yard line number. (#459)
 - Fixed play description in some 1999 and 2000 games where the string "D.Holland" replaced the kick distance. (#459)
 - Fixed a problem where the `goal_to_go` variable was `FALSE` in actual goal to go situations. (#460)
+- Fixed a bug in `fixed_drive` and `fixed_drive_result` where the second weather delay in `2023_13_ARI_PIT` wasn't identified correctly. (#461)
 
 # nflfastR 4.6.1
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -146,7 +146,7 @@ add_nflscrapr_mutations <- function(pbp) {
       lead_ko = case_when(
         dplyr::lead(.data$kickoff_attempt) == 1 &
           .data$game_id == dplyr::lead(.data$game_id) &
-          !stringr::str_detect(tolower(.data$play_description), "(injured sf )|(tonight's attendance )|(injury update )|(end quarter)|(timeout)|( captains:)|( captains )|( captians:)|( humidity:)|(note - )|( deferred)|(game start )") &
+          !stringr::str_detect(tolower(.data$play_description), "(injured sf )|(tonight's attendance )|(injury update )|(end quarter)|(timeout)|( captains:)|( captains )|( captians:)|( humidity:)|(note - )|( deferred)|(game start )|( game has been suspended)") &
           !stringr::str_detect(.data$play_description, "GAME ") &
           !.data$play_description %in% c("GAME", "Two-Minute Warning", "The game has resumed.") &
           is.na(.data$two_point_conv_result) &


### PR DESCRIPTION
There is this logic where we set kickoff_attempt to 1 mostly for plays with penalties. 

The logic uses previous play data and skips the kickoff_attempt in various situations. The logic includes that we skip a kickott_attempt if the play description of the previous play says "The game has resumed" after it has been suspended for whatever reason.

However, in 2023_13_ARI_PIT the games has been suspended twice and after the second one there ways no "The game has resumed" which made the logic set kickoff_attempt == 1 and ultimately resulted in wrong `fixed_drive` numbers (#447).

This PR explicitly avoids kickoff_attempt if the previous play description says "game has been suspended". This fixes #447 but it might fail in the future if the "The game has resumed" play is missing and the play description varies for some reason.