### PR TITLE
Add new penalty type from dynamic kickoff rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 4.6.1.9016
+Version: 4.6.1.9017
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - nflfastR tried to fix bugs in the underlying pbp data of JAX home games prior to the 2016 season. An update of the raw pbp data resolved those bugs so nflfastR needs to remove the hard coded adjustments. This means that nflfastR <= v4.6.1 will return incorrect pbp data for all Jacksonville home games prior to the 2016 season! (#478)
 - Fixed a problem where `clean_pbp()` returned `pass = 1` in actual rush plays in very rare cases. (#479)
 - Removed extra lines for injury timeouts that were breaking `fixed_drive` (#482)
+- The variable `penalty_type` now correctly lists the penalty "Kickoff Short of Landing Zone" introduced in the 2024 season. (#486)
 
 # nflfastR 4.6.1
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -92,6 +92,12 @@ add_nflscrapr_mutations <- function(pbp) {
           stringr::str_remove("\\([0-9]{2}+ Yards\\)") %>%
           stringr::str_squish(), NA_character_
       ),
+      # The new "dynamic Kickoff" in the 2024 season introduces a new penalty type
+      penalty_type = dplyr::if_else(
+        .data$penalty == 1 & stringr::str_detect(tolower(.data$play_description), "kickoff short of landing zone"),
+        "Kickoff Short of Landing Zone",
+        .data$penalty_type
+      ),
       # Make plays marked with down == 0 as NA:
       down = dplyr::if_else(
         .data$down == 0,


### PR DESCRIPTION
Here is an example of plays where nflfastR didn't parse the penalty type
![image](https://github.com/user-attachments/assets/d239e786-db9e-4f8f-aec5-d7279b391281)
