### PR TITLE
Catch missing `spread_line` data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.0.0.9000
+Version: 5.0.0.9001
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # nflfastR (development version)
 
 - Fixed a bug where `calculate_stats()` incorrectly counted `receiving_air_yards`. (#500)
+- Fixed a bug where `vegas_wp` variables were broken when `spread_line` data was missing. (#503)
 
 # nflfastR 5.0.0
 

--- a/R/helper_add_ep_wp.R
+++ b/R/helper_add_ep_wp.R
@@ -196,6 +196,24 @@ wp_spread_model_select <- function(pbp) {
 }
 prepare_wp_data <- function(pbp) {
 
+  if (any(is.na(pbp$spread_line))){
+    broken_games <- pbp %>%
+      dplyr::filter(is.na(.data$spread_line)) %>%
+      dplyr::pull(game_id) %>%
+      unique() %>%
+      sort()
+    cli::cli_alert_danger(
+      "The following game{?s} {?is/are} missing valid spread lines: {.val {broken_games}}."
+    )
+    cli::cli_alert_warning(
+      "nflfastR will manually set the spread for the home team to {.val 1.5} points!"
+    )
+    cli::cli_alert_warning(
+      "If you see this, please reach out to the package maintainers {.url https://github.com/nflverse/nflfastR/issues}"
+    )
+    pbp$spread_line[is.na(pbp$spread_line)] <- 1.5
+  }
+
   pbp <- pbp %>%
     dplyr::group_by(.data$game_id) %>%
     dplyr::mutate(

--- a/nflfastR.Rproj
+++ b/nflfastR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: e1e14382-386c-49b3-9b3f-206a4cc98503
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Fixes #502 

vegas_wp variables were completely broken when spread_line data is NA. 

The result is a bouncing win probability that doesn't make any sense. 

![image](https://github.com/user-attachments/assets/b7e0304e-7b57-4493-8a1f-aeb9dd430a7d)

We decided to avoid this extreme result by setting `NA` spread lines to 1.5 (~ home field advantage). However, since that is not the actual line, we warn the user and ask them to create an issue. 
```
✖ The following game is missing valid spread lines: "2024_17_ARI_LA".
✖ nflfastR will manually set the spread for the home team to "1.5" points!
! If you see this, please reach out to the package maintainers <https://github.com/nflverse/nflfastR/issues>
```

The result of the manual overwrite looks far better, tho it is still wrong
![image](https://github.com/user-attachments/assets/b5b5af9e-c64c-47f2-87e6-f8901546b064)
