### PR TITLE
deprecate standings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.0.0.9002
+Version: 5.0.0.9003
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Imports:
 Suggests: 
     DBI,
     gsisdecoder,
-    nflseedR (>= 1.0.2),
+    nflseedR (>= 2.0.0),
     purrr (>= 0.3.0),
     rmarkdown,
     RSQLite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Fixed a bug where `calculate_stats()` incorrectly counted `receiving_air_yards`. (#500)
 - Fixed a bug where `vegas_wp` variables were broken when `spread_line` data was missing. (#503)
 - Fixed a bug where `calculate_stats()` incorrectly calculated `target_share` and `air_yards_share` when `summary_level = "season"`. (#505)
+- The function `calculate_standings()` has been deprecated. Please use `nflseedR::nfl_standings()` in nflseedR v2.0 instead. (#510)
 
 # nflfastR 5.0.0
 

--- a/R/calculate_standings.R
+++ b/R/calculate_standings.R
@@ -1,6 +1,11 @@
 #' Compute Division Standings and Conference Seeds from Play by Play
 #'
-#' @description This function calculates division standings as well as playoff
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' This function was deprecated and replaced by [nflseedR::nfl_standings()].
+#'
+#' This function calculates division standings as well as playoff
 #'   seeds per conference based on either nflverse play-by-play data or nflverse
 #'   schedule data.
 #'
@@ -14,6 +19,7 @@
 #'   for all seasons in `nflverse_object`!
 #' @inheritParams nflseedR::compute_conference_seeds
 #'
+#' @keywords internal
 #' @return A tibble with NFL regular season standings
 #' @export
 #'
@@ -34,6 +40,11 @@
 calculate_standings <- function(nflverse_object,
                                 tiebreaker_depth = 3,
                                 playoff_seeds = NULL){
+  lifecycle::deprecate_warn(
+    "5.1.0",
+    "calculate_standings()",
+    "nflseedR::nfl_standings()"
+  )
 
   if(!inherits(nflverse_object, "nflverse_data")){
     cli::cli_abort("The function argument {.arg nflverse_object} has to be

--- a/man/calculate_standings.Rd
+++ b/man/calculate_standings.Rd
@@ -35,6 +35,10 @@ for all seasons in \code{nflverse_object}!}
 A tibble with NFL regular season standings
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+This function was deprecated and replaced by \code{\link[nflseedR:nfl_standings]{nflseedR::nfl_standings()}}.
+
 This function calculates division standings as well as playoff
 seeds per conference based on either nflverse play-by-play data or nflverse
 schedule data.
@@ -54,3 +58,4 @@ try({# to avoid CRAN test problems
 })
 }
 }
+\keyword{internal}


### PR DESCRIPTION
closes #491 

This PR deprecates `calculate_standings()`. The deprecation message will tell the user to use `nflseedR::nfl_standings()` instead.
I decided against re-exporting `nfl_standings`. User should just go the nflseedR way.