### PR TITLE
support raw model format in fastrmodels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.0.0.9005
+Version: 5.0.0.9006
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - The function `calculate_standings()` has been deprecated. Please use `nflseedR::nfl_standings()` in nflseedR v2.0 instead. (#510)
 - nflfastR now requires R 4.1 to allow the package to use R's native pipe `|>` operator. This follows the [Tidyverse R version support rules](https://www.tidyverse.org/blog/2019/04/r-version-support/). (#511)
 - Fixed a bug where `calculate_stats()` incorrectly counted `fumbles`. (#514)
+- Compatibility improvements with xgboost.
 
 # nflfastR 5.0.0
 

--- a/R/ep_wp_calculators.R
+++ b/R/ep_wp_calculators.R
@@ -67,7 +67,7 @@ calculate_expected_points <- function(pbp_data) {
   )
 
   preds <- as.data.frame(
-    matrix(stats::predict(fastrmodels::ep_model, as.matrix(model_data)), ncol = 7, byrow = TRUE)
+    matrix(stats::predict(load_model("ep"), as.matrix(model_data)), ncol = 7, byrow = TRUE)
   )
 
   colnames(preds) <- c(

--- a/R/helper_add_cp_cpoe.R
+++ b/R/helper_add_cp_cpoe.R
@@ -13,7 +13,7 @@ add_cp <- function(pbp) {
   passes <- prepare_cp_data(pbp)
 
   if (!nrow(passes |> dplyr::filter(.data$valid_pass == 1)) == 0) {
-    pred <- stats::predict(fastrmodels::cp_model, as.matrix(passes |> dplyr::select(-"complete_pass", -"valid_pass"))) |>
+    pred <- stats::predict(load_model("cp"), as.matrix(passes |> dplyr::select(-"complete_pass", -"valid_pass"))) |>
       tibble::as_tibble() |>
       dplyr::rename(cp = "value") |>
       dplyr::bind_cols(passes) |>

--- a/R/helper_add_ep_wp.R
+++ b/R/helper_add_ep_wp.R
@@ -96,7 +96,7 @@ get_preds <- function(pbp) {
   }
 
   preds <- as.data.frame(
-    matrix(stats::predict(fastrmodels::ep_model, as.matrix(pbp |> ep_model_select())), ncol=7, byrow=TRUE)
+    matrix(stats::predict(load_model("ep"), as.matrix(pbp |> ep_model_select())), ncol=7, byrow=TRUE)
   )
 
   colnames(preds) <- c("Touchdown","Opp_Touchdown","Field_Goal","Opp_Field_Goal",
@@ -109,7 +109,7 @@ get_preds <- function(pbp) {
 #for predict stage
 get_preds_wp <- function(pbp) {
 
-  preds <- stats::predict(fastrmodels::wp_model, as.matrix(pbp |> wp_model_select()))
+  preds <- stats::predict(load_model("wp"), as.matrix(pbp |> wp_model_select()))
 
   return(preds)
 }
@@ -118,7 +118,7 @@ get_preds_wp <- function(pbp) {
 #for predict stage
 get_preds_wp_spread <- function(pbp) {
 
-  preds <- stats::predict(fastrmodels::wp_model_spread, as.matrix(pbp |> wp_spread_model_select()))
+  preds <- stats::predict(load_model("wp_spread"), as.matrix(pbp |> wp_spread_model_select()))
 
   return(preds)
 }

--- a/R/helper_add_xpass.R
+++ b/R/helper_add_xpass.R
@@ -30,7 +30,7 @@ add_xpass <- function(pbp, ...) {
     user_message("Computing xpass...", "todo")
 
     pred <- stats::predict(
-      fastrmodels::xpass_model,
+      load_model("xpass"),
       as.matrix(plays |> dplyr::select(-"valid_play"))
       ) |>
       tibble::as_tibble() |>

--- a/R/helper_add_xyac.R
+++ b/R/helper_add_xyac.R
@@ -52,7 +52,7 @@ add_xyac <- function(pbp, ...) {
 
       xyac_vars <-
         stats::predict(
-          fastrmodels::xyac_model,
+          load_model("xyac"),
           as.matrix(passes |> xyac_model_select())
         ) |>
         tibble::as_tibble() |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -208,3 +208,24 @@ release_bullets <- function() {
     NULL
   )
 }
+
+load_model <- function(name){
+  model <- switch(name,
+    "ep" = fastrmodels::ep_model,
+    "cp" = fastrmodels::cp_model,
+    "wp" = fastrmodels::wp_model,
+    "wp_spread" = fastrmodels::wp_model_spread,
+    "fg" = fastrmodels::fg_model,
+    "xpass" = fastrmodels::xpass_model,
+    "xyac" = fastrmodels::xyac_model
+  )
+
+  # fastrmodels v1.0.3 introduced raw model vectors to make sure the models
+  # are compatible with future xgboost versions
+  out <- if (is.raw(model)) {
+    xgboost::xgb.load.raw(model)
+  } else {
+    model
+  }
+  out
+}


### PR DESCRIPTION
This is a nflfastR backend change that allows us to make xgboost models in fastrmodels compatible with future xgboost updates to get rid of annoying warnings.