### PR TITLE
uniquify play IDs in some 2000 games

### DIFF
--- a/R/build_playstats.R
+++ b/R/build_playstats.R
@@ -29,13 +29,16 @@ build_playstats <- function(seasons = nflreadr::most_recent_season(),
         drives <- raw_data[[1]][["drives"]] |>
           purrr::keep(is.list)
         out <- tibble::tibble(d = drives) |>
-          tidyr::unnest_wider(.data$d) |>
-          tidyr::unnest_longer(.data$plays) |>
-          tidyr::unnest_wider(.data$plays, names_sep = "_") |>
+          tidyr::unnest_wider("d") |>
+          tidyr::unnest_longer("plays") |>
+          tidyr::unnest_wider("plays", names_sep = "_") |>
           dplyr::select("playId" = "plays_id", "playStats" = "plays_players") |>
-          tidyr::unnest_longer(.data$playStats) |>
-          tidyr::unnest_longer(.data$playStats) |>
-          tidyr::unnest_wider(.data$playStats) |>
+          dplyr::mutate(
+            playId = uniquify_ids(.data$playId)
+          ) |>
+          tidyr::unnest_longer("playStats") |>
+          tidyr::unnest_longer("playStats") |>
+          tidyr::unnest_wider("playStats") |>
           dplyr::mutate(
             playId = as.integer(.data$playId),
             statId = as.integer(.data$statId),
@@ -49,12 +52,12 @@ build_playstats <- function(seasons = nflreadr::most_recent_season(),
           ) |>
           tidyr::nest(
             playStats = c(
-              .data$statId,
-              .data$yards,
-              .data$playerName,
-              .data$team.id,
-              .data$team.abbreviation,
-              .data$gsis.Player.id
+              "statId",
+              "yards",
+              "playerName",
+              "team.id",
+              "team.abbreviation",
+              "gsis.Player.id"
             )
           )
       } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -70,6 +70,23 @@ maybe_valid <- function(id) {
   )
 }
 
+# some 2000 games have play_ids like 2767.375 and 2767.703 which results in
+# duplicates that can be fixed. We save play IDs as numeric first and then
+# check whether or not there are duplicates when we convert them to integer
+# If there are duplicates, we multiply all play IDs by 10 and check again
+# If there are still duplicates, we multiply all play IDs by 100 and so on
+# As soon as play IDs are unique, we save them as integer and go on
+uniquify_ids <- function(ids){
+  ids <- as.numeric(ids)
+  int_ids <- as.integer(ids)
+  mult <- 10
+  while (anyDuplicated(int_ids) > 0) {
+    int_ids <- as.integer(ids * mult)
+    mult <- mult * 10
+  }
+  int_ids
+}
+
 # check if a package is installed
 is_installed <- function(pkg) requireNamespace(pkg, quietly = TRUE)
 


### PR DESCRIPTION
The result will be that affected games of the 2000 season will have their play IDs multiplied by 10, 100, or 1000 but there is no other way to make sure play IDs are unique.