### PR TITLE
Add "Kickoff Out of Bounds" `penalty_type`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.1.0.9008
+Version: 5.1.0.9009
 Authors@R: 
     c(person(given = "Sebastian",
              family = "Carl",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - `fast_scraper_roster()` and `fast_scraper_schedules()` are officially deprecated and will be removed in a future update. Please use `load_rosters()` and `load_schedules()`. (#539)
 - `report()` is deprecated and will be removed in a future update. Please use `nflverse_sitrep()`. (#540)
 - Fixed incompatibility with xgboost v3 model outputs. (#553)
+- Added `"Kickoff Out of Bounds"` (introduced in the 2024 season) to the `penalty_type` variable in play-by-play. (#560)
 
 # nflfastR 5.1.0
 

--- a/R/helper_add_nflscrapr_mutations.R
+++ b/R/helper_add_nflscrapr_mutations.R
@@ -92,10 +92,15 @@ add_nflscrapr_mutations <- function(pbp) {
           stringr::str_remove("\\([0-9]{2}+ Yards\\)") |>
           stringr::str_squish(), NA_character_
       ),
-      # The new "dynamic Kickoff" in the 2024 season introduces a new penalty type
+      # The new "dynamic Kickoff" in the 2024 season introduces new penalty types
       penalty_type = dplyr::if_else(
         .data$penalty == 1 & stringr::str_detect(tolower(.data$play_description), "kickoff short of landing zone"),
         "Kickoff Short of Landing Zone",
+        .data$penalty_type
+      ),
+      penalty_type = dplyr::if_else(
+        .data$penalty == 1 & stringr::str_detect(tolower(.data$play_description), "kickoff out of bounds"),
+        "Kickoff Out of Bounds",
         .data$penalty_type
       ),
       # Make plays marked with down == 0 as NA:


### PR DESCRIPTION
fixes #557 

All 55 instances of this penalty are now correctly recognized.

<img width="1379" height="446" alt="image" src="https://github.com/user-attachments/assets/bba74a8b-ecd9-4e71-83fb-26359ed29a12" />
