### PR TITLE
Stats fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.2.0.9009
+Version: 5.2.0.9010
 Authors@R: c(
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = "aut"),
     person("Ben", "Baldwin", , "bbaldwin206@gmail.com", role = c("cre", "aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 - Added several punting stats to the output of `calculate_stats()`. (#574)
 - Added overall fumble counters to the output of `calculate_stats()` because it was missing some edge case fumbles on offense. (#575)
 - The `play_type` variable now possibly shows `"pass"` or `"run"` on 2 point conversion plays with a post-snap penalty enforced between downs. This is different from `play_type_nfl` (which will show `"PENALTY"` in these cases). (#579)
+- Fixed bug where `calculate_stats()` counted fumble recoveries in `fumble_recovery_yards_own` and `fumble_recovery_yards_opp` instead of the corresponding yards. (#584)
+- Fixed bug where `calculate_stats()` counted some blocked punts as punt attempts that officially do not count as punt attempts. (#584)
 
 # nflfastR 5.2.0
 

--- a/R/calculate_stats.R
+++ b/R/calculate_stats.R
@@ -447,11 +447,11 @@ calculate_stats <- function(
       fumble_recovery_own = sum(stat_id %in% 55:56),
       # 57, 58 don't count as recovery because player received a
       # lateral after recovery by other player
-      fumble_recovery_yards_own = sum(stat_id %in% 55:58),
+      fumble_recovery_yards_own = sum((stat_id %in% 55:58) * yards),
       fumble_recovery_opp = sum(stat_id %in% 59:60),
       # 61, 62 don't count as recovery because player received a
       # lateral after recovery by other player
-      fumble_recovery_yards_opp = sum(stat_id %in% 59:62),
+      fumble_recovery_yards_opp = sum((stat_id %in% 59:62) * yards),
       fumble_recovery_tds = sum(stat_id %in% c(56, 58, 60, 62)),
       penalties = sum(stat_id == 93),
       penalty_yards = sum((stat_id == 93) * yards),

--- a/R/calculate_stats.R
+++ b/R/calculate_stats.R
@@ -533,7 +533,8 @@ calculate_stats <- function(
       },
 
       # Punts #####################
-      pt_att = sum(stat_id %in% c(2, 29, 31, 32)), # 31 probably unnecessary
+      # stat ID 2 counts blocked punts that do not count as punt
+      pt_att = sum(stat_id %in% c(29, 31, 32)), # 31 probably unnecessary
       pt_blocked = sum(stat_id == 2),
       pt_long = max(stat_id %in% c(29, 32) * yards) %0% NA_integer_,
       pt_yards = sum(stat_id %in% c(29, 32) * yards),


### PR DESCRIPTION
closes #583 
closes #580 

Two minor bugs are fixed here

1. we counted stat ID 2 as punt but it turns out that stat ID 2 is used on punt attempts that do not count as punt (#583)
2. we forgot to multiply fumble recoveries with yards (#580)