### PR TITLE
The search string for `has_id` didn't correctly handle single digit stat IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.2.0.9010
+Version: 5.2.0.9011
 Authors@R: c(
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = "aut"),
     person("Ben", "Baldwin", , "bbaldwin206@gmail.com", role = c("cre", "aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - The `play_type` variable now possibly shows `"pass"` or `"run"` on 2 point conversion plays with a post-snap penalty enforced between downs. This is different from `play_type_nfl` (which will show `"PENALTY"` in these cases). (#579)
 - Fixed bug where `calculate_stats()` counted fumble recoveries in `fumble_recovery_yards_own` and `fumble_recovery_yards_opp` instead of the corresponding yards. (#584)
 - Fixed bug where `calculate_stats()` counted some blocked punts as punt attempts that officially do not count as punt attempts. (#584)
+- Fixed bug where `calculate_stats()` overcounted first downs in some edge cases. (#587)
 
 # nflfastR 5.2.0
 

--- a/R/calculate_stats.R
+++ b/R/calculate_stats.R
@@ -144,24 +144,24 @@ calculate_stats <- function(
     dplyr::rename("player_id" = "gsis_player_id", "team" = "team_abbr") |>
     dplyr::group_by(.data$season, .data$week, .data$play_id, .data$player_id) |>
     dplyr::mutate(
-      # we append a collapse separator to the string in order to search for matches
-      # including the separator to avoid 1 matching 10
-      more_stats = paste0(paste(stat_id, collapse = ";"), ";")
+      # we wrap the collapsed string in ";" in order to search for the pattern
+      # ";stat_id;" to avoid matching 1 with 10, 11, 21, etc.
+      more_stats = paste0(";", paste(stat_id, collapse = ";"), ";")
     ) |>
     dplyr::group_by(.data$season, .data$week, .data$play_id, .data$team) |>
     dplyr::mutate(
-      # we append a collapse separator to the string in order to search for matches
-      # including the separator to avoid 1 matching 10
-      team_stats = paste0(paste(stat_id, collapse = ";"), ";"),
+      # we wrap the collapsed string in ";" in order to search for the pattern
+      # ";stat_id;" to avoid matching 1 with 10, 11, 21, etc.
+      team_stats = paste0(";", paste(stat_id, collapse = ";"), ";"),
       team_play_air_yards = sum((stat_id %in% 111:112) * yards)
     ) |>
     # need to group by game and play here to avoid mixing of play IDs of different
     # games in the same week
     dplyr::group_by(.data$game_id, .data$play_id) |>
     dplyr::mutate(
-      # we append a collapse separator to the string in order to search for matches
-      # including the separator to avoid 1 matching 10
-      all_stats = paste0(paste(stat_id, collapse = ";"), ";"),
+      # we wrap the collapsed string in ";" in order to search for the pattern
+      # ";stat_id;" to avoid matching 1 with 10, 11, 21, etc.
+      all_stats = paste0(";", paste(stat_id, collapse = ";"), ";"),
       play_punt_return_yards = sum((stat_id %in% 33:36) * yards)
     ) |>
     # compute team targets and team air yards for calculation of target share
@@ -716,7 +716,7 @@ fg_list <- function(stat_ids, yards, collapse_id, gwfg = NULL) {
 `%ifna%` <- function(lhs, rhs) data.table::fifelse(is.na(lhs), rhs, lhs)
 
 has_id <- function(id, all_ids) {
-  stringr::str_detect(all_ids, paste0(id, ";", collapse = "|"))
+  stringr::str_detect(all_ids, paste0(";", id, ";", collapse = "|"))
 }
 
 td_ids <- function() {


### PR DESCRIPTION
closes #585 

We use `has_id` to search a string of concatenated stat IDs for a specific stat ID because sometimes we need team level stats on the player level, e.g. first downs.

The old approach appended a ";" to the search string and searched for "stat_id;". However, this led to false positives where 3 or 4 were reported in strings like "10;53;54;".

This PR wraps the search string in ";" on both sides and searches for ";stat_id;". I should have done this to begin with.