### PR TITLE
Redirect nflfastR to load raw pbp from nflverse-pbp releases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nflfastR
 Title: Functions to Efficiently Access NFL Play by Play Data
-Version: 5.2.0.9011
+Version: 5.2.0.9012
 Authors@R: c(
     person("Sebastian", "Carl", , "mrcaseb@gmail.com", role = "aut"),
     person("Ben", "Baldwin", , "bbaldwin206@gmail.com", role = c("cre", "aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - Fixed bug where `calculate_stats()` counted fumble recoveries in `fumble_recovery_yards_own` and `fumble_recovery_yards_opp` instead of the corresponding yards. (#584)
 - Fixed bug where `calculate_stats()` counted some blocked punts as punt attempts that officially do not count as punt attempts. (#584)
 - Fixed bug where `calculate_stats()` overcounted first downs in some edge cases. (#587)
+- nflfastR now loads raw play-by-play data from season based releases in the `nflverse/nflverse-pbp` GitHub repository. The legacy repository `nflverse/nflfastR-raw` is deprecated and won't update in future seasons. This means that previous nflfastR versions won't be able to download 2026+ seasons! (#589)
 
 # nflfastR 5.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 - Fixed a bug where `fixed_drive` did not increment after a muffed blocked field goal attempt. Yes this happened in `"2025_10_NO_CAR"`, play id 2504. (#567)
 - nflfastR stopped supporting the 1999 and 2000 seasons because of inconsistent data sources. Data is still available through `load_pbp()` but we will not fix any issues related to those old seasons anymore. It's possible to install nflfastR v5.2.0 (with `pak::pak("nflverse/nflfastR@v5.2.0")`) to parse those seasons if necessary. (#568)
 - Implemented a fresh approach to compute `play_type` based on `play_type_nfl` for faster and more consistent output. (#568)
-- Fixed a bug where nflfastR overrode the kickoff_attempt variable in the event of a penalty on a kickoff. (#569)
+- Fixed a bug where nflfastR overwrote the kickoff_attempt variable in the event of a penalty on a kickoff. (#569)
 - Added various definitions of 'explosive' plays to the output of `calculate_stats()`. It counts passes, runs, and receptions with 10+, 20+, 40+ yards gained as well as 12+ yard runs and 16+ yard passes. (#573)
 - Added several punting stats to the output of `calculate_stats()`. (#574)
 - Added overall fumble counters to the output of `calculate_stats()` because it was missing some edge case fumbles on offense. (#575)

--- a/R/save_raw_pbp.R
+++ b/R/save_raw_pbp.R
@@ -67,18 +67,21 @@ save_raw_pbp <- function(
     dir.create,
     FUN.VALUE = logical(1L)
   )
-  to_load <- file.path(
-    "https://raw.githubusercontent.com/nflverse/nflfastR-raw/master/raw",
-    seasons,
-    paste0(game_ids, ".rds"),
-    fsep = "/"
-  )
+  to_load <- raw_pbp_urls(game_ids)
   save_to <- file.path(
     dir,
     seasons,
     paste0(game_ids, ".rds")
   )
-  curl::multi_download(to_load, save_to)
+  dl <- curl::multi_download(to_load, save_to)
+  failed <- dl$status_code != 200
+  if (any(failed)) {
+    cli::cli_alert_danger(
+      "Failed to download: {.var {game_ids[failed]}}"
+    )
+    file.remove(save_to[failed])
+  }
+  dl
 }
 
 #' Compute Missing Raw PBP Data on Local Filesystem

--- a/R/utils.R
+++ b/R/utils.R
@@ -118,12 +118,7 @@ load_raw_game <- function(
     # cli::cli_progress_step("Load locally from {.path {local_file}}")
     raw <- readRDS(local_file)
   } else {
-    to_load <- file.path(
-      "https://raw.githubusercontent.com/nflverse/nflfastR-raw/master/raw",
-      season,
-      paste0(game_id, ".rds"),
-      fsep = "/"
-    )
+    to_load <- raw_pbp_urls(game_id)
     raw <- nflreadr::rds_from_url(to_load)
   }
 
@@ -193,12 +188,7 @@ fetch_raw <- function(
   season <- substr(game_id, 1, 4)
 
   if (is.null(dir)) {
-    to_load <- file.path(
-      "https://raw.githubusercontent.com/nflverse/nflfastR-raw/master/raw",
-      season,
-      paste0(game_id, ".rds"),
-      fsep = "/"
-    )
+    to_load <- raw_pbp_urls(game_id)
 
     fetched <- curl::curl_fetch_memory(to_load)
 
@@ -346,4 +336,15 @@ check_for_dropped_seasons <- function(game_ids) {
     game_ids <- game_ids[!game_ids %in% dropped_support]
   }
   game_ids
+}
+
+raw_pbp_urls <- function(game_ids){
+  # pattern
+  # https://github.com/nflverse/nflverse-pbp/releases/download/{season}/{game_id}.rds
+  file.path(
+    "https://github.com/nflverse/nflverse-pbp/releases/download",
+    paste0("raw_pbp_", substr(game_ids, 1, 4)),
+    paste0(game_ids, ".rds"),
+    fsep = "/"
+  )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -338,7 +338,7 @@ check_for_dropped_seasons <- function(game_ids) {
   game_ids
 }
 
-raw_pbp_urls <- function(game_ids){
+raw_pbp_urls <- function(game_ids) {
   # pattern
   # https://github.com/nflverse/nflverse-pbp/releases/download/{season}/{game_id}.rds
   file.path(


### PR DESCRIPTION
closes #588 

while testing this I also realized that `save_raw_pbp()` should remove failed downloads because `missing_raw_pbp()` would otherwise skip those